### PR TITLE
makefile/build fixes

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -21,7 +21,7 @@ clean:
 
 install: all
 	echo -e "    \033[1mINSTALL\033[0m $(BINDIR)/rove"
-	install -d rove $(BINDIR)
+	install -D rove $(BINDIR)
 
 rove: $(OBJS)
 	echo -e "    \033[1mLD\033[0m      src/rove"

--- a/src/Makefile
+++ b/src/Makefile
@@ -21,7 +21,7 @@ clean:
 
 install: all
 	echo -e "    \033[1mINSTALL\033[0m $(BINDIR)/rove"
-	install rove $(BINDIR)
+	install -d rove $(BINDIR)
 
 rove: $(OBJS)
 	echo -e "    \033[1mLD\033[0m      src/rove"

--- a/src/Makefile
+++ b/src/Makefile
@@ -21,7 +21,7 @@ clean:
 
 install: all
 	echo -e "    \033[1mINSTALL\033[0m $(BINDIR)/rove"
-	$(INSTALL) -d rove $(BINDIR)
+	$(INSTALL) -d $(BINDIR)
 
 rove: $(OBJS)
 	echo -e "    \033[1mLD\033[0m      src/rove"

--- a/src/Makefile
+++ b/src/Makefile
@@ -21,7 +21,7 @@ clean:
 
 install: all
 	echo -e "    \033[1mINSTALL\033[0m $(BINDIR)/rove"
-	install -D rove $(BINDIR)
+	$(INSTALL) -d rove $(BINDIR)
 
 rove: $(OBJS)
 	echo -e "    \033[1mLD\033[0m      src/rove"

--- a/src/Makefile
+++ b/src/Makefile
@@ -22,6 +22,7 @@ clean:
 install: all
 	echo -e "    \033[1mINSTALL\033[0m $(BINDIR)/rove"
 	$(INSTALL) -d $(BINDIR)
+	$(INSTALL) rove $(BINDIR)
 
 rove: $(OBJS)
 	echo -e "    \033[1mLD\033[0m      src/rove"


### PR DESCRIPTION
It took a few tries, but I finally got working build fixes.

This makes it friendly to packagers regardless of distribution, since package managers aren't supposed to touch the live filesystem, but use sandboxes. There were some weird bits in rove's Makefiles, so this brings it in line with the working code in libmonome, which is similarly styled.

I will have some more fixes soon for autotools usefulness, since the existing configure/make stuff is homebrewed. Mostly easy DESTDIR sed fixes, which are nice'n'universal.

In the meantime, this commit gets the Makefile goin' in a (fail)safe way. As a side benefit, it makes the job easier for packagers like me; I'm getting rove into Gentoo! There are at least 2 Gentoo users with monomes....this'll help. :)
